### PR TITLE
Replace srtm4 dependency by SRTM DEM on GCS

### DIFF
--- a/rpcm/__init__.py
+++ b/rpcm/__init__.py
@@ -5,10 +5,10 @@ import geojson
 import numpy as np
 import rasterio
 import rasterio.warp
-import srtm4
 
 from rpcm import rpc_model
 from rpcm import utils
+from rpcm.dem import get_copernicus_elevation
 from rpcm.rpc_model import RPCModel
 from rpcm.rpc_model import rpc_from_geotiff
 from rpcm.rpc_model import rpc_from_rpc_file
@@ -54,7 +54,7 @@ def projection(img_path, lon, lat, z=None, crop_path=None, svg_path=None,
     """
     rpc = rpc_from_geotiff(img_path)
     if z is None:
-        z = srtm4.srtm4(lon, lat)
+        z = get_copernicus_elevation(lon, lat)
 
     x, y = rpc.projection(lon, lat, z)
 
@@ -126,7 +126,7 @@ def crop(output_crop_path, input_geotiff_path, aoi, z=None):
     """
     if z is None:  # read z from srtm
         lons, lats = np.asarray(aoi['coordinates']).squeeze().T
-        z = srtm4.srtm4(np.mean(lons[:-1]), np.mean(lats[:-1]))
+        z = get_copernicus_elevation(np.mean(lons[:-1]), np.mean(lats[:-1]))
 
     # do the crop
     crop, x, y = utils.crop_aoi(input_geotiff_path, aoi, z)
@@ -165,7 +165,7 @@ def image_footprint(geotiff_path, z=None, verbose=False):
     if rpc_dict:
         rpc = rpc_model.RPCModel(rpc_dict)
         if z is None:
-            z = srtm4.srtm4(rpc.lon_offset, rpc.lat_offset)
+            z = get_copernicus_elevation(rpc.lon_offset, rpc.lat_offset)
             if np.isnan(z):
                 warnings.warn("no SRTM altitude available, using RPC alt_offset",
                               category=NoSRTMWarning)
@@ -215,7 +215,7 @@ def angle_between_views(geotiff_path_1, geotiff_path_2, lon=None, lat=None,
     if lat is None:
         lat = rpc1.lat_offset
     if z is None:
-        z = srtm4.srtm4(lon, lat)
+        z = get_copernicus_elevation(lon, lat)
 
     a = utils.viewing_direction(*rpc1.incidence_angles(lon, lat, z))
     b = utils.viewing_direction(*rpc2.incidence_angles(lon, lat, z))

--- a/rpcm/__init__.py
+++ b/rpcm/__init__.py
@@ -8,7 +8,7 @@ import rasterio.warp
 
 from rpcm import rpc_model
 from rpcm import utils
-from rpcm.dem import get_copernicus_elevation
+from rpcm.dem import get_srtm_elevations
 from rpcm.rpc_model import RPCModel
 from rpcm.rpc_model import rpc_from_geotiff
 from rpcm.rpc_model import rpc_from_rpc_file
@@ -54,7 +54,9 @@ def projection(img_path, lon, lat, z=None, crop_path=None, svg_path=None,
     """
     rpc = rpc_from_geotiff(img_path)
     if z is None:
-        z = get_copernicus_elevation(lon, lat)
+        z = get_srtm_elevations(lon, lat, True)
+        if len(z) == 1:
+            z = z[0]
 
     x, y = rpc.projection(lon, lat, z)
 
@@ -126,7 +128,7 @@ def crop(output_crop_path, input_geotiff_path, aoi, z=None):
     """
     if z is None:  # read z from srtm
         lons, lats = np.asarray(aoi['coordinates']).squeeze().T
-        z = get_copernicus_elevation(np.mean(lons[:-1]), np.mean(lats[:-1]))
+        z = get_srtm_elevations([np.mean(lons[:-1])], [np.mean(lats[:-1])], True)[0]
 
     # do the crop
     crop, x, y = utils.crop_aoi(input_geotiff_path, aoi, z)
@@ -165,7 +167,7 @@ def image_footprint(geotiff_path, z=None, verbose=False):
     if rpc_dict:
         rpc = rpc_model.RPCModel(rpc_dict)
         if z is None:
-            z = get_copernicus_elevation(rpc.lon_offset, rpc.lat_offset)
+            z = get_srtm_elevations([rpc.lon_offset], [rpc.lat_offset], True)[0]
             if np.isnan(z):
                 warnings.warn("no SRTM altitude available, using RPC alt_offset",
                               category=NoSRTMWarning)
@@ -215,7 +217,7 @@ def angle_between_views(geotiff_path_1, geotiff_path_2, lon=None, lat=None,
     if lat is None:
         lat = rpc1.lat_offset
     if z is None:
-        z = get_copernicus_elevation(lon, lat)
+        z = get_srtm_elevations([lon], [lat], True)[0]
 
     a = utils.viewing_direction(*rpc1.incidence_angles(lon, lat, z))
     b = utils.viewing_direction(*rpc2.incidence_angles(lon, lat, z))

--- a/rpcm/__init__.py
+++ b/rpcm/__init__.py
@@ -54,9 +54,10 @@ def projection(img_path, lon, lat, z=None, crop_path=None, svg_path=None,
     """
     rpc = rpc_from_geotiff(img_path)
     if z is None:
-        z = get_srtm_elevations(lon, lat, True)
-        if len(z) == 1:
-            z = z[0]
+        if isinstance(lon, list) and isinstance(lat, list):
+            z = get_srtm_elevations(lon, lat, True)
+        else:
+            z = get_srtm_elevations([lon], [lat], True)[0]
 
     x, y = rpc.projection(lon, lat, z)
 

--- a/rpcm/dem.py
+++ b/rpcm/dem.py
@@ -1,0 +1,9 @@
+import rasterio as rio
+
+GCS_COPERNICUS_DEM_VRT = "gs://overstory-dtms/CopernicusDem30m/copernicus_dem/dem.vrt"
+
+def get_copernicus_elevation(lon: float, lat: float):
+    with rio.open(GCS_COPERNICUS_DEM_VRT) as src:
+        assert src.crs == "EPSG:4326"
+        elevation = list(src.sample([(lon, lat)]))[0]
+    return elevation

--- a/rpcm/dem.py
+++ b/rpcm/dem.py
@@ -1,9 +1,36 @@
+import os
+
+import pyproj
 import rasterio as rio
 
-GCS_COPERNICUS_DEM_VRT = "gs://overstory-dtms/CopernicusDem30m/copernicus_dem/dem.vrt"
+pyproj.network.set_network_enabled(active=True)
+os.environ["PROJ_UNSAFE_SSL"] = "TRUE"  # Required by pyproj to download external datum information
 
-def get_copernicus_elevation(lon: float, lat: float):
-    with rio.open(GCS_COPERNICUS_DEM_VRT) as src:
+SRTM_VRT = "gs://overstory-dtms/srtm_v41_90m/index.vrt"
+
+
+def get_srtm_elevations(lons: list[float], lats: list[float], convert_ellipsoidal: bool) -> list[float]:
+    with rio.open(SRTM_VRT) as src:
         assert src.crs == "EPSG:4326"
-        elevation = list(src.sample([(lon, lat)]))[0]
-    return elevation
+        elevations = [float(e[0]) for e in src.sample([(lon, lat) for lon, lat in zip(lons, lats)])]
+        # Convert nodata
+        elevations = [e if e != src.nodata else float("nan") for e in elevations]
+    # Convert to ellipsoidal heights
+    if convert_ellipsoidal:
+        return to_ellipsoid(lons, lats, elevations)
+    return elevations
+
+
+def to_ellipsoid(lons: list[float], lats: list[float], elevations: list[float]) -> list[float]:
+    """
+    Convert geoidal heights to ellipsoidal heights.
+    """
+    # WGS84 with ellipsoid height as vertical axis
+    ellipsoid = pyproj.CRS.from_epsg(4979)
+    # WGS84 with Gravity-related height (EGM96)
+    geoid = pyproj.CRS("EPSG:4326+5773")
+
+    trf = pyproj.Transformer.from_crs(geoid, ellipsoid)
+    new_elevations = trf.transform(lats, lons, elevations, errcheck=True)[-1]
+
+    return [round(new_alt, 2) for new_alt in new_elevations]

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ def readme():
 requirements = ['numpy',
                 'pyproj',
                 'geojson',
-                'rasterio[s3]>=1.2',
-                'srtm4>=1.0.2']
+                'rasterio[s3]>=1.2']
 
 extras_require = {'test': ['pytest']}
 


### PR DESCRIPTION
# Problem
`srtm4` is a python library that downloads srtm files locally and then reads them to extract elevation data at specific latitudes and longitudes. There are two problems with `srtm4`:
1. The large srtm tiles are downloaded at every data-ingestion pipeline run. This takes time and is inefficient.
2. The `srtm4` library [requires special treatment to run locally on MacOS and complicates local development](https://github.com/20treeAI/data-ingestion?tab=readme-ov-file#srtm4-install-error-on-macos).

# Solution

~~We already have a Copernicus DEM on GCS which dynamically builds up as new tiles are required. We could obtain elevation data by very quickly reading the elevation points from these cloud optimized geotifs.~~
I've downloaded the full SRTM v4.1 (90m) dataset at `gs://overstory-dtms/srtm_v41_90m` and built a vrt index. This can be used to very efficiently query for elevations at specific latitudes and longitudes.

## To Do
- [x] Download full or partial SRTM DEM dataset. Keep in a notebook/pipeline if we ever need to recreate or expand the dataset. 
- [x] Make a vrt file on GCS to link all the tiles together


# Reproducibility

Here is a script demonstrating the difference between using SRTM ourselves instead of using srtm4 library:
```
from typing import List
import rasterio as rio
from rasterio.windows import Window
import srtm4

pyproj.network.set_network_enabled(active=True)
import os
os.environ["PROJ_UNSAFE_SSL"]="TRUE"


SRTM_VRT = "gs://overstory-dtms/srtm_v41_90m/index.vrt"
lons = [-72.2,  -102, -98, -115, -77]
lats = [45.4 , 50  , 35  , 33. , 37]

def get_srtm_elevations(lons: List[float], lats: List[float], convert_ellipsoidal: bool):
    with rio.open(SRTM_VRT) as src:
        assert src.crs == "EPSG:4326"
        elevations = [float(e[0]) for e in src.sample([(lon, lat) for lon, lat in zip(lons, lats)])]
        # Convert nodata
        elevations = [e if e != src.nodata else float("nan") for e in elevations]
        # Convert to ellipsoidal heights
        if convert_ellipsoidal:
            elevations = to_ellipsoid(lons, lats, elevations)
    return elevations

def to_ellipsoid(lons: List[float], lats: List[float], elevations: List[float]):
    """
    Convert geoidal heights to ellipsoidal heights.
    """
    # WGS84 with ellipsoid height as vertical axis
    ellipsoid = pyproj.CRS.from_epsg(4979)
    # WGS84 with Gravity-related height (EGM96)
    geoid = pyproj.CRS("EPSG:4326+5773")

    trf = pyproj.Transformer.from_crs(geoid, ellipsoid)
    new_elevations = trf.transform(lats, lons, elevations, errcheck=True)[-1]

    return [round(new_alt, 2) for new_alt in new_elevations]


old_elev = srtm4.srtm4(lons, lats)
print(old_elev)

new_elev = get_srtm_elevations(lons, lats, True)
print(new_elev)
```
Output is:
```
[266.777, 618.553, 342.51, 122.856, -5.45667]
[275.74, 618.55, 339.5, 123.86, -0.46]
```
The values are very similar, but not exactly the same. It's possible that `srtm4` does a bit more than just converting to ellipsoidal height. Maybe it's related to the half-pixel offset due to the srtm geotifs having the wrong `AREA_OR_POINT` tiftag: https://github.com/centreborelli/srtm4/blob/master/srtm4/raster.py#L2-L6