### PR TITLE
remove s3 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def readme():
 requirements = ['numpy',
                 'pyproj',
                 'geojson',
-                'rasterio[s3]>=1.2']
+                'rasterio>=1.2']
 
 extras_require = {'test': ['pytest']}
 


### PR DESCRIPTION
We currently get the DEM from GCS, seems like `s3` isn't needed anywhere.